### PR TITLE
feat(docker): replace dev server with multi-stage production build

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+.env*
+*.local

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,17 +1,14 @@
-# Frontend Dockerfile
-FROM node:20-alpine
-
+# Stage 1: Build
+FROM node:20-alpine AS builder
 WORKDIR /app
-
-# Install dependencies
 COPY package*.json ./
 RUN npm ci
-
-# Copy source
 COPY . .
+RUN npm run build
 
-# Expose port
-EXPOSE 5173
-
-# Start dev server (for development)
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+# Stage 2: Serve
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml image/svg+xml;
+}


### PR DESCRIPTION
Switches from Vite dev server to a multi-stage build: Node compiles the app, nginx serves the static output. Adds nginx.conf with SPA fallback and gzip, and .dockerignore to keep build context clean.